### PR TITLE
fix(backend): use npm ci instead of npm install for deterministic dep…

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Installer les dépendances Node.js
-RUN npm install --only=production
+RUN npm ci
 
 # Copier le code source
 COPY . .


### PR DESCRIPTION
…endency installation

- Replace 'npm install --only=production' with 'npm ci'
- Ensures all dependencies from package-lock.json are properly installed
- Fixes MODULE_NOT_FOUND error for passport-google-oauth20